### PR TITLE
Few fixes/enhancements.

### DIFF
--- a/amp.EtoForms/FormMain.Events.cs
+++ b/amp.EtoForms/FormMain.Events.cs
@@ -82,6 +82,7 @@ partial class FormMain
                 selectedTracks.ToArray());
 
             e.Handled = true;
+            gvAudioTracks.Focus();
             return;
         }
 
@@ -241,6 +242,7 @@ partial class FormMain
             {
                 gvAudioTracks.SelectedRow = displayTrack;
                 gvAudioTracks.ScrollToRow(displayTrack);
+                gvAudioTracks.Focus();
             }
 
             if (track != null)

--- a/amp.EtoForms/FormMain.Layout.cs
+++ b/amp.EtoForms/FormMain.Layout.cs
@@ -324,6 +324,25 @@ partial class FormMain
         trackInfoCommand.Image = EtoHelpers.ImageFromSvg(Colors.SteelBlue,
             Size16.ic_fluent_info_16_filled, Globals.ButtonDefaultSize);
 
+        var addFilesSubMenu = new SubMenuItem
+        {
+            Image = EtoHelpers.ImageFromSvg(Colors.Teal, Size20.ic_fluent_collections_add_20_filled,
+                Globals.MenuImageDefaultSize),
+            Text = UI.AddMusicFiles,
+        };
+
+
+        if (!Globals.Settings.HideAddFilesToNonAlbum)
+        {
+            addFilesSubMenu.Items.Add(addFilesToDatabase);
+        }
+        addFilesSubMenu.Items.Add(addFilesToAlbum);
+        if (!Globals.Settings.HideAddFilesToNonAlbum)
+        {
+            addFilesSubMenu.Items.Add(addDirectoryToDatabase);
+        }
+        addFilesSubMenu.Items.Add(addDirectoryToAlbum);
+
         // create menu
         base.Menu = new MenuBar
         {
@@ -336,18 +355,7 @@ partial class FormMain
             ApplicationItems =
             {
                 // application (OS X) or file menu (others)
-                new SubMenuItem
-                {
-                    Image = EtoHelpers.ImageFromSvg(Colors.Teal, Size20.ic_fluent_collections_add_20_filled, Globals.MenuImageDefaultSize),
-                    Text = UI.AddMusicFiles,
-                    Items =
-                    {
-                        addFilesToDatabase,
-                        addFilesToAlbum,
-                        addDirectoryToDatabase,
-                        addDirectoryToAlbum,
-                    },
-                },
+                addFilesSubMenu,
                 manageAlbumsCommand,
                 trackInfoCommand,
                 settingsCommand,

--- a/amp.EtoForms/FormMain.Methods.cs
+++ b/amp.EtoForms/FormMain.Methods.cs
@@ -256,6 +256,11 @@ SOFTWARE.
 
             gvAudioTracks.DataStore = filteredTracks;
             UpdateCounters();
+
+            if (userIdle && !gvAudioTracks.HasFocus)
+            {
+                gvAudioTracks.Focus();
+            }
         });
     }
 

--- a/amp.EtoForms/Settings/Settings.cs
+++ b/amp.EtoForms/Settings/Settings.cs
@@ -291,5 +291,12 @@ public class Settings : ApplicationJsonSettings, IBiasedRandomSettings
     /// <value>The selected album reference identifier.</value>
     [Settings(Default = 1L)]
     public long SelectedAlbum { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to hide the add files menu items which do not add tracks to an album.
+    /// </summary>
+    /// <value><c>true</c> if to hide the menu items to add files to a database only; otherwise, <c>false</c>.</value>
+    [Settings(Default = true)]
+    public bool HideAddFilesToNonAlbum { get; set; }
     #endregion
 }


### PR DESCRIPTION
The track grid playing track is now highlighted if the user goes idle. Closes #44 .
The queue via [+] button doesn't defocus the grid anymore. Closes #47 .
Currently hide the two confusing sub menu items by default in the settings.