### PR TITLE
Fix EF core DB concurrency

### DIFF
--- a/amp.Database/ExtensionClasses/DbContextExtensions.cs
+++ b/amp.Database/ExtensionClasses/DbContextExtensions.cs
@@ -64,6 +64,37 @@ public static class DbContextExtensions
         }
     }
 
+    /// <summary>
+    /// Save changes to database context and stops tracking the specified entities after saving the changes.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entities to untrack.</typeparam>
+    /// <param name="context">The database context.</param>
+    /// <param name="entities">The entities to untrack.</param>
+    /// <returns>A Task&lt;System.Int32&gt; representing the asynchronous operation.</returns>
+    public static async Task<int> SaveChangesAndUntrackAsync<TEntity>(this DbContext context, params TEntity[] entities)
+    {
+        var result = await context.SaveChangesAsync();
+        context.Untrack(entities);
+        return result;
+    }
+
+    /// <summary>
+    /// Removes the specified entities from being tracked.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entities to remove.</typeparam>
+    /// <param name="context">The database context.</param>
+    /// <param name="entities">The entities to untrack.</param>
+    private static void Untrack<TEntity>(this DbContext context, params TEntity[] entities)
+    {
+        foreach (var entity in entities)
+        {
+            if (entity != null)
+            {
+                context.Entry(entity).State = EntityState.Detached;
+            }
+        }
+    }
+
     private static void UpdateEntity(IEntity destination, IEntity source)
     {
         var propertyInfos = destination.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);

--- a/amp.EtoForms/Classes/AlbumTrackMethods.cs
+++ b/amp.EtoForms/Classes/AlbumTrackMethods.cs
@@ -27,6 +27,7 @@ SOFTWARE.
 using System.Collections.ObjectModel;
 using amp.DataAccessLayer.DtoClasses;
 using amp.Database;
+using amp.Database.ExtensionClasses;
 using Eto.Forms;
 using EtoForms.Controls.Custom.Utilities;
 using Microsoft.EntityFrameworkCore;
@@ -56,6 +57,7 @@ internal static class AlbumTrackMethods
                 var toRemove = await context.AlbumTracks.Where(f => selectedTrackIds.Contains(f.Id)).ToListAsync();
                 context.AlbumTracks.RemoveRange(toRemove);
                 await context.SaveChangesAsync();
+                context.ChangeTracker.Clear();
             });
 
             if (result)
@@ -88,7 +90,7 @@ internal static class AlbumTrackMethods
 
             gridView.ReloadData(gridView.SelectedRow);
 
-            await context.SaveChangesAsync();
+            await context.SaveChangesAndUntrackAsync(updateTrack);
         }
     }
 
@@ -106,7 +108,7 @@ internal static class AlbumTrackMethods
             updateTrack.PlaybackVolume = volume;
             updateTrack.ModifiedAtUtc = DateTime.UtcNow;
             albumTrack.AudioTrack!.PlaybackVolume = volume;
-            await context.SaveChangesAsync();
+            await context.SaveChangesAndUntrackAsync(updateTrack);
         });
     }
 
@@ -124,7 +126,7 @@ internal static class AlbumTrackMethods
             updateTrack.Rating = trackRating;
             updateTrack.ModifiedAtUtc = DateTime.UtcNow;
             albumTrack.AudioTrack!.Rating = trackRating;
-            await context.SaveChangesAsync();
+            await context.SaveChangesAndUntrackAsync(updateTrack);
         });
     }
 
@@ -140,7 +142,7 @@ internal static class AlbumTrackMethods
                 albumTrack.AudioTrack.PlayedByUser = updateTrack.PlayedByUser;
                 albumTrack.AudioTrack.ModifiedAtUtc = updateTrack.ModifiedAtUtc;
             }
-            await context.SaveChangesAsync();
+            await context.SaveChangesAndUntrackAsync(updateTrack);
         });
     }
 }

--- a/amp.EtoForms/Dialogs/DialogModifySavedQueue.cs
+++ b/amp.EtoForms/Dialogs/DialogModifySavedQueue.cs
@@ -27,6 +27,7 @@ SOFTWARE.
 using System.Collections.ObjectModel;
 using amp.DataAccessLayer.DtoClasses;
 using amp.Database;
+using amp.Database.ExtensionClasses;
 using amp.EtoForms.Utilities;
 using amp.Shared.Localization;
 using Eto.Drawing;
@@ -248,6 +249,7 @@ internal class DialogModifySavedQueue : Dialog<bool>
 
             await context.SaveChangesAsync();
             await transaction.CommitAsync();
+            context.ChangeTracker.Clear();
         }, async (_) => await transaction.RollbackAsync());
 
         Close(true);
@@ -262,7 +264,7 @@ internal class DialogModifySavedQueue : Dialog<bool>
         track.QueueSnapshotId = queueTrack.QueueSnapshotId;
         track.QueueIndex = queueTrack.QueueIndex;
 
-        await context.SaveChangesAsync();
+        await context.SaveChangesAndUntrackAsync(track);
     }
 
     private void BtnCancel_Click(object? sender, EventArgs e)

--- a/amp.EtoForms/Dialogs/DialogUpdateTagData.cs
+++ b/amp.EtoForms/Dialogs/DialogUpdateTagData.cs
@@ -242,6 +242,8 @@ public class DialogUpdateTagData : Dialog
             });
         }
 
+        context.ChangeTracker.Clear();
+
         await Application.Instance.InvokeAsync(() =>
         {
             btnClose.Enabled = true;

--- a/amp.EtoForms/Dialogs/FormAddFilesProgress.cs
+++ b/amp.EtoForms/Dialogs/FormAddFilesProgress.cs
@@ -423,6 +423,7 @@ public class FormAddFilesProgress : Form
                 }
 
                 await context.SaveChangesAsync(userAbortToken);
+                context.ChangeTracker.Clear();
             }
             catch (Exception ex)
             {

--- a/amp.EtoForms/FormMain.Events.cs
+++ b/amp.EtoForms/FormMain.Events.cs
@@ -28,6 +28,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using amp.DataAccessLayer;
 using amp.Database.DataModel;
+using amp.Database.ExtensionClasses;
 using amp.Database.QueryHelpers;
 using amp.EtoForms.Classes;
 using amp.EtoForms.Dialogs;
@@ -300,7 +301,7 @@ partial class FormMain
                 var updateEntity = await context.AudioTracks.FirstOrDefaultAsync(f => f.Id == result.AudioTrackId);
                 result.AudioTrack.UpdateDataModel(updateEntity);
 
-                await context.SaveChangesAsync();
+                await context.SaveChangesAndUntrackAsync(updateEntity);
             }
 
         });
@@ -395,8 +396,7 @@ partial class FormMain
                     : albumTrack.AudioTrack.SkippedEarlyCount + 1;
                 albumTrack.AudioTrack.ModifiedAtUtc = DateTime.UtcNow;
                 context.Update(albumTrack);
-                await context.SaveChangesAsync();
-                context.ChangeTracker.Clear();
+                await context.SaveChangesAndUntrackAsync(albumTrack);
             }
         });
     }
@@ -752,7 +752,7 @@ partial class FormMain
         if (track != null)
         {
             e.AudioTrack.UpdateDataModel(track);
-            var count = await context.SaveChangesAsync();
+            var count = await context.SaveChangesAndUntrackAsync(track);
             e.SaveSuccess = count > 0;
             if (e.SaveSuccess)
             {

--- a/amp.EtoForms/FormMain.Methods.cs
+++ b/amp.EtoForms/FormMain.Methods.cs
@@ -159,6 +159,7 @@ partial class FormMain
         }
 
         var count = await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
 
         gvAudioTracks.ReloadKeepSelection();
 

--- a/amp.EtoForms/amp.EtoForms.csproj
+++ b/amp.EtoForms/amp.EtoForms.csproj
@@ -17,6 +17,7 @@
 		<DocumentationFile>bin\$(Configuration)\amp.EtoForms.xml</DocumentationFile>
 		<IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
 		<IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+		<IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
 		<Version>1.0.2.0</Version>
 	</PropertyGroup>
 
@@ -26,6 +27,10 @@
 
 	<PropertyGroup Condition="'$(IsWindows)'=='true'">
 		<DefineConstants>Windows</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(IsLinux)'=='true'">
+		<DefineConstants>Linux</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes EF core DB concurrency errors by keeping the change tracker cleared. The concurrency errors occur due the application being multi-threaded but multiple database contexts would be an overkill for fix in a desktop application,